### PR TITLE
[schedy] Fixed bug in filter_entities()

### DIFF
--- a/hass_apps/schedy/expression/helpers.py
+++ b/hass_apps/schedy/expression/helpers.py
@@ -119,9 +119,8 @@ class StateHelper(HelperBase):
                 if attr == "state": 
                     if state.get("state") != value:
                         break
-                else:
-                    if attributes.get(attr) != value:
-                        break
+                elif attributes.get(attr) != value:
+                    break
             else:
                 yield entity
 

--- a/hass_apps/schedy/expression/helpers.py
+++ b/hass_apps/schedy/expression/helpers.py
@@ -116,9 +116,12 @@ class StateHelper(HelperBase):
                 continue
             attributes = state.get("attributes", {})
             for attr, value in criteria.items():
-                if attr == "state" and state.get("state") != value or \
-                   attributes.get(attr) != value:
-                    break
+                if attr == "state": 
+                    if state.get("state") != value:
+                        break
+                else:
+                    if attributes.get(attr) != value:
+                        break
             else:
                 yield entity
 


### PR DESCRIPTION
When the state and attributes were filtered at the same time, like in the example in the docs:
```filter_entities('binary_sensor', window_room=room_name, state='on'))```

```filter_entities``` always returned nothing.